### PR TITLE
docs(openapi): intégrer swagger-jsdoc et annoter toutes les routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "passport-local": "^1.0.0",
         "prisma": "^7.5.0",
         "socket.io": "^4.8.3",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -33,10 +35,56 @@
         "@types/node": "^25.5.0",
         "@types/passport": "^1.0.17",
         "@types/passport-local": "^1.0.38",
+        "@types/swagger-jsdoc": "^6.0.4",
+        "@types/swagger-ui-express": "^4.1.8",
         "nodemon": "^3.1.14",
         "socket.io-client": "^4.8.3",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
@@ -151,6 +199,12 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
     },
     "node_modules/@mrleebo/prisma-ast": {
       "version": "0.13.1",
@@ -343,6 +397,13 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -453,6 +514,12 @@
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
@@ -581,6 +648,24 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/swagger-jsdoc": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
+      "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -649,6 +734,12 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
@@ -851,6 +942,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
+    },
     "node_modules/chevrotain": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
@@ -888,6 +985,21 @@
       "dependencies": {
         "consola": "^3.2.3"
       }
+    },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.2.4",
@@ -1053,6 +1165,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/dotenv": {
@@ -1247,6 +1371,15 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1395,6 +1528,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1488,6 +1627,27 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -1499,6 +1659,34 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/gopd": {
@@ -1632,6 +1820,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1720,6 +1919,18 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
@@ -1778,6 +1989,13 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1788,6 +2006,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -1812,6 +2037,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -2198,6 +2429,13 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2242,6 +2480,15 @@
       "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -3079,6 +3326,62 @@
         "node": ">=4"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.1.tgz",
+      "integrity": "sha512-6HQoo7+j8PA2QqP5kgAb9dl1uxUjvR0SAoL/WUp1sTEvm0F6D5npgU2OGCLwl++bIInqGlEUQ2mpuZRZYtyCzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -3244,6 +3547,15 @@
         }
       }
     },
+    "node_modules/validator": {
+      "version": "13.15.26",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
+      "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -3313,6 +3625,15 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -3321,6 +3642,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/zeptomatch": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "passport-local": "^1.0.0",
     "prisma": "^7.5.0",
     "socket.io": "^4.8.3",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -41,6 +43,8 @@
     "@types/node": "^25.5.0",
     "@types/passport": "^1.0.17",
     "@types/passport-local": "^1.0.38",
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui-express": "^4.1.8",
     "nodemon": "^3.1.14",
     "socket.io-client": "^4.8.3",
     "ts-node": "^10.9.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,10 +2,35 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
+import swaggerUi from 'swagger-ui-express';
 import { router } from './routes';
 import { errorMiddleware } from './middlewares/error.middleware';
+import { swaggerSpec } from './config/swagger';
 
 const app = express();
+
+// Swagger UI — CSP assouplie uniquement pour /api/docs
+app.use(
+    '/api/docs',
+    helmet({
+        contentSecurityPolicy: {
+            directives: {
+                defaultSrc: ["'self'"],
+                scriptSrc: ["'self'", "'unsafe-inline'"],
+                styleSrc: ["'self'", "'unsafe-inline'"],
+                imgSrc: ["'self'", 'data:', 'https:'],
+                connectSrc: ["'self'"],
+            },
+        },
+    }),
+    swaggerUi.serve,
+    swaggerUi.setup(swaggerSpec, {
+        customSiteTitle: 'GamePlatform API Docs',
+        swaggerOptions: {
+            persistAuthorization: true, // conserve le token entre les rechargements
+        },
+    }),
+);
 
 // Middlewares globaux
 app.use(helmet());
@@ -13,6 +38,12 @@ app.use(cors());
 app.use(morgan('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+
+// Spec OpenAPI brute (JSON) — utile pour les outils tiers
+app.get('/api/docs.json', (req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.send(swaggerSpec);
+});
 
 // Routes
 app.use('/api', router);

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1,0 +1,196 @@
+import swaggerJsdoc from 'swagger-jsdoc';
+import path from 'path';
+
+const options: swaggerJsdoc.Options = {
+    definition: {
+        openapi: '3.0.0',
+        info: {
+            title: 'GamePlatform API',
+            version: '1.0.0',
+            description:
+                'API REST de la plateforme de jeux en ligne multi-joueurs.\n\n' +
+                '## Authentification\n' +
+                'Les routes protégées nécessitent un token JWT dans le header `Authorization: Bearer <token>`.\n' +
+                'Obtenez un token via `POST /auth/login`. Durée de vie : **7 jours**.\n\n' +
+                '## Format des erreurs\n' +
+                '- **Validation (400)** : `{ message, errors: [{ field, message }] }`\n' +
+                '- **Métier** : `{ message }`',
+            contact: {
+                name: 'Lucas Martinelle — ENSIM 4A',
+            },
+        },
+        servers: [
+            {
+                url: '/api',
+                description: 'Serveur local (développement)',
+            },
+        ],
+        tags: [
+            { name: 'Health', description: 'Santé du serveur' },
+            { name: 'Auth', description: 'Inscription, connexion, profil JWT' },
+            { name: 'Users', description: "Profil de l'utilisateur connecté" },
+            { name: 'Games', description: 'Jeux disponibles et leaderboard' },
+            { name: 'Scores', description: 'Soumission de scores' },
+            { name: 'Matches', description: 'Gestion des parties (REST)' },
+            { name: 'Home', description: "Contenu éditorial de la page d'accueil (public)" },
+            { name: 'Admin — Users', description: "Gestion des utilisateurs (réservé ADMIN)" },
+            { name: 'Admin — Content', description: "Gestion du contenu éditorial (réservé ADMIN)" },
+        ],
+        components: {
+            securitySchemes: {
+                bearerAuth: {
+                    type: 'http',
+                    scheme: 'bearer',
+                    bearerFormat: 'JWT',
+                    description: 'Token JWT obtenu via POST /auth/login',
+                },
+            },
+            schemas: {
+                // ── Utilisateur ──────────────────────────────────────────────
+                User: {
+                    type: 'object',
+                    properties: {
+                        id: { type: 'string', format: 'uuid', example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' },
+                        email: { type: 'string', format: 'email', example: 'user@example.com' },
+                        username: { type: 'string', minLength: 3, maxLength: 20, example: 'my_username' },
+                        role: { type: 'string', enum: ['PLAYER', 'ADMIN'], example: 'PLAYER' },
+                        suspended: { type: 'boolean', example: false },
+                        createdAt: { type: 'string', format: 'date-time' },
+                        updatedAt: { type: 'string', format: 'date-time' },
+                    },
+                },
+                // ── Jeu ──────────────────────────────────────────────────────
+                Game: {
+                    type: 'object',
+                    properties: {
+                        id: { type: 'string', format: 'uuid' },
+                        name: { type: 'string', example: 'Tic-Tac-Toe' },
+                        slug: { type: 'string', example: 'tic-tac-toe' },
+                        description: { type: 'string', nullable: true, example: 'Le classique jeu de morpion à deux joueurs.' },
+                        coverImage: { type: 'string', nullable: true, example: null },
+                        createdAt: { type: 'string', format: 'date-time' },
+                    },
+                },
+                // ── Match ─────────────────────────────────────────────────────
+                MatchPlayer: {
+                    type: 'object',
+                    properties: {
+                        matchId: { type: 'string', format: 'uuid' },
+                        userId: { type: 'string', format: 'uuid' },
+                        role: { type: 'string', enum: ['PLAYER', 'SPECTATOR'] },
+                        score: { type: 'integer', nullable: true },
+                        user: {
+                            type: 'object',
+                            properties: {
+                                id: { type: 'string', format: 'uuid' },
+                                username: { type: 'string' },
+                            },
+                        },
+                    },
+                },
+                Match: {
+                    type: 'object',
+                    properties: {
+                        id: { type: 'string', format: 'uuid' },
+                        status: { type: 'string', enum: ['WAITING', 'ONGOING', 'FINISHED'] },
+                        createdAt: { type: 'string', format: 'date-time' },
+                        endedAt: { type: 'string', format: 'date-time', nullable: true },
+                        gameId: { type: 'string', format: 'uuid' },
+                        game: {
+                            type: 'object',
+                            properties: {
+                                id: { type: 'string', format: 'uuid' },
+                                name: { type: 'string' },
+                                slug: { type: 'string' },
+                            },
+                        },
+                        players: {
+                            type: 'array',
+                            items: { $ref: '#/components/schemas/MatchPlayer' },
+                        },
+                    },
+                },
+                // ── Score ─────────────────────────────────────────────────────
+                Score: {
+                    type: 'object',
+                    properties: {
+                        id: { type: 'string', format: 'uuid' },
+                        value: { type: 'integer', minimum: 0, example: 1 },
+                        createdAt: { type: 'string', format: 'date-time' },
+                    },
+                },
+                LeaderboardEntry: {
+                    type: 'object',
+                    properties: {
+                        id: { type: 'string', format: 'uuid' },
+                        value: { type: 'integer', example: 1 },
+                        createdAt: { type: 'string', format: 'date-time' },
+                        user: {
+                            type: 'object',
+                            properties: {
+                                id: { type: 'string', format: 'uuid' },
+                                username: { type: 'string' },
+                            },
+                        },
+                    },
+                },
+                UserScore: {
+                    type: 'object',
+                    properties: {
+                        id: { type: 'string', format: 'uuid' },
+                        value: { type: 'integer', example: 1 },
+                        createdAt: { type: 'string', format: 'date-time' },
+                        game: {
+                            type: 'object',
+                            properties: {
+                                id: { type: 'string', format: 'uuid' },
+                                name: { type: 'string' },
+                                slug: { type: 'string' },
+                            },
+                        },
+                    },
+                },
+                // ── HomeContent ───────────────────────────────────────────────
+                HomeContent: {
+                    type: 'object',
+                    properties: {
+                        id: { type: 'string', format: 'uuid' },
+                        key: { type: 'string', example: 'hero_title' },
+                        value: { type: 'string', example: 'Bienvenue sur GamePlatform' },
+                        updatedAt: { type: 'string', format: 'date-time' },
+                    },
+                },
+                // ── Erreurs ───────────────────────────────────────────────────
+                Error: {
+                    type: 'object',
+                    properties: {
+                        message: { type: 'string', example: 'Ressource introuvable' },
+                    },
+                },
+                ValidationError: {
+                    type: 'object',
+                    properties: {
+                        message: { type: 'string', example: 'Erreur de validation' },
+                        errors: {
+                            type: 'array',
+                            items: {
+                                type: 'object',
+                                properties: {
+                                    field: { type: 'string', example: 'email' },
+                                    message: { type: 'string', example: 'Adresse email invalide' },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+    // swagger-jsdoc scanne ces fichiers pour extraire les annotations @openapi
+    apis: [
+        path.join(__dirname, '../routes/index.ts'),
+        path.join(__dirname, '../modules/**/*.routes.ts'),
+    ],
+};
+
+export const swaggerSpec = swaggerJsdoc(options);

--- a/src/modules/admin/admin.routes.ts
+++ b/src/modules/admin/admin.routes.ts
@@ -5,9 +5,245 @@ import { isAdmin } from '../../middlewares/role.middleware';
 
 export const adminRouter = Router();
 
+/**
+ * @openapi
+ * /admin/users:
+ *   get:
+ *     tags:
+ *       - Admin — Users
+ *     summary: Liste paginée des utilisateurs
+ *     description: |
+ *       Retourne la liste paginée de tous les utilisateurs.
+ *       La recherche est insensible à la casse et porte sur `username` et `email`.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: Numéro de page
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *         description: Nombre d'utilisateurs par page
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *           example: alice
+ *         description: Filtre par username ou email (insensible à la casse)
+ *     responses:
+ *       200:
+ *         description: Liste paginée des utilisateurs
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/User'
+ *                 total:
+ *                   type: integer
+ *                   description: Nombre total d'utilisateurs (avant pagination)
+ *                   example: 42
+ *                 page:
+ *                   type: integer
+ *                   example: 1
+ *                 limit:
+ *                   type: integer
+ *                   example: 20
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ */
 adminRouter.get('/users', isAuthenticated, isAdmin, adminController.getUsers);
+
+/**
+ * @openapi
+ * /admin/users/{id}/suspend:
+ *   patch:
+ *     tags:
+ *       - Admin — Users
+ *     summary: Suspendre ou réactiver un utilisateur
+ *     description: |
+ *       Un utilisateur suspendu ne peut plus se connecter (`POST /auth/login` retourne 400).
+ *       Passez `suspended: false` pour lever la suspension.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: Identifiant de l'utilisateur
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [suspended]
+ *             properties:
+ *               suspended:
+ *                 type: boolean
+ *                 example: true
+ *     responses:
+ *       200:
+ *         description: Statut mis à jour
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 user:
+ *                   $ref: '#/components/schemas/User'
+ *       400:
+ *         description: Le champ suspended est invalide
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         description: Utilisateur introuvable
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 adminRouter.patch('/users/:id/suspend', isAuthenticated, isAdmin, adminController.suspendUser);
+
+/**
+ * @openapi
+ * /admin/users/{id}:
+ *   delete:
+ *     tags:
+ *       - Admin — Users
+ *     summary: Supprimer un utilisateur
+ *     description: Supprime définitivement le compte d'un utilisateur et toutes ses données associées.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       204:
+ *         description: Utilisateur supprimé (aucun corps)
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         description: Utilisateur introuvable
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 adminRouter.delete('/users/:id', isAuthenticated, isAdmin, adminController.deleteUser);
 
+/**
+ * @openapi
+ * /admin/home-content:
+ *   get:
+ *     tags:
+ *       - Admin — Content
+ *     summary: Contenu éditorial (admin)
+ *     description: Retourne toutes les entrées de contenu, triées par clé alphabétique.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Liste des entrées de contenu
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 content:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/HomeContent'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ */
 adminRouter.get('/home-content', isAuthenticated, isAdmin, adminController.getHomeContent);
+
+/**
+ * @openapi
+ * /admin/home-content/{key}:
+ *   patch:
+ *     tags:
+ *       - Admin — Content
+ *     summary: Créer ou mettre à jour une entrée de contenu
+ *     description: |
+ *       Crée l'entrée si elle n'existe pas, la met à jour sinon (upsert).
+ *
+ *       **Clés disponibles après le seed :**
+ *       - `hero_title` — Titre principal de la page d'accueil
+ *       - `hero_subtitle` — Sous-titre
+ *       - `hero_cta` — Texte du bouton d'appel à l'action
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: key
+ *         required: true
+ *         schema:
+ *           type: string
+ *           example: hero_title
+ *         description: Clé de l'entrée de contenu
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [value]
+ *             properties:
+ *               value:
+ *                 type: string
+ *                 example: "Bienvenue sur la plateforme de jeux !"
+ *     responses:
+ *       200:
+ *         description: Entrée créée ou mise à jour
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 item:
+ *                   $ref: '#/components/schemas/HomeContent'
+ *       400:
+ *         description: Le champ value est manquant ou vide
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ */
 adminRouter.patch('/home-content/:key', isAuthenticated, isAdmin, adminController.upsertHomeContent);

--- a/src/modules/auth/auth.routes.ts
+++ b/src/modules/auth/auth.routes.ts
@@ -4,6 +4,160 @@ import { isAuthenticated } from '../../middlewares/auth.middleware';
 
 export const authRouter = Router();
 
+/**
+ * @openapi
+ * /auth/register:
+ *   post:
+ *     tags:
+ *       - Auth
+ *     summary: Inscription
+ *     description: Crée un nouveau compte utilisateur avec le rôle `PLAYER`.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [email, username, password]
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 example: user@example.com
+ *               username:
+ *                 type: string
+ *                 minLength: 3
+ *                 maxLength: 20
+ *                 pattern: '^[a-zA-Z0-9_]+$'
+ *                 description: "3–20 caractères : lettres, chiffres, underscores"
+ *                 example: my_username
+ *               password:
+ *                 type: string
+ *                 minLength: 8
+ *                 example: monMotDePasse123
+ *     responses:
+ *       201:
+ *         description: Utilisateur créé avec succès
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 user:
+ *                   $ref: '#/components/schemas/User'
+ *       400:
+ *         description: Validation échouée ou email/username déjà utilisé
+ *         content:
+ *           application/json:
+ *             schema:
+ *               oneOf:
+ *                 - $ref: '#/components/schemas/ValidationError'
+ *                 - $ref: '#/components/schemas/Error'
+ *             examples:
+ *               emailPris:
+ *                 summary: Email déjà utilisé
+ *                 value:
+ *                   message: "Cette adresse email est déjà utilisée"
+ *               usernamePris:
+ *                 summary: Username déjà pris
+ *                 value:
+ *                   message: "Ce nom d'utilisateur est déjà pris"
+ */
 authRouter.post('/register', authController.register);
+
+/**
+ * @openapi
+ * /auth/login:
+ *   post:
+ *     tags:
+ *       - Auth
+ *     summary: Connexion
+ *     description: |
+ *       Authentifie un utilisateur et retourne un token JWT valable **7 jours**.
+ *
+ *       Utilisez ce token dans le header `Authorization: Bearer <token>` pour
+ *       toutes les requêtes authentifiées.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [email, password]
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 example: admin@example.com
+ *               password:
+ *                 type: string
+ *                 example: Admin1234!
+ *     responses:
+ *       200:
+ *         description: Connexion réussie
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 token:
+ *                   type: string
+ *                   description: Token JWT Bearer
+ *                   example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+ *                 user:
+ *                   $ref: '#/components/schemas/User'
+ *       400:
+ *         description: Identifiants invalides ou compte suspendu
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *             examples:
+ *               invalides:
+ *                 value: { message: "Identifiants invalides" }
+ *               suspendu:
+ *                 value: { message: "Ce compte est suspendu" }
+ */
 authRouter.post('/login', authController.login);
+
+/**
+ * @openapi
+ * /auth/me:
+ *   get:
+ *     tags:
+ *       - Auth
+ *     summary: Profil depuis le token JWT
+ *     description: |
+ *       Retourne les données embarquées dans le payload JWT (pas de requête BDD).
+ *       Préférer `GET /users/me` pour des données fraîches depuis la base.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Données du payload JWT
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 user:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       format: uuid
+ *                     email:
+ *                       type: string
+ *                     username:
+ *                       type: string
+ *                     role:
+ *                       type: string
+ *                       enum: [PLAYER, ADMIN]
+ *       401:
+ *         description: Token absent ou invalide
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 authRouter.get('/me', isAuthenticated, authController.me);

--- a/src/modules/games/games.routes.ts
+++ b/src/modules/games/games.routes.ts
@@ -6,13 +6,317 @@ import { isAdmin } from '../../middlewares/role.middleware';
 
 export const gamesRouter = Router();
 
+/**
+ * @openapi
+ * /games:
+ *   get:
+ *     tags:
+ *       - Games
+ *     summary: Liste des jeux
+ *     description: Retourne tous les jeux disponibles sur la plateforme.
+ *     responses:
+ *       200:
+ *         description: Liste des jeux
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 games:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Game'
+ */
 gamesRouter.get('/', gamesController.listGames);
+
+/**
+ * @openapi
+ * /games:
+ *   post:
+ *     tags:
+ *       - Games
+ *     summary: Créer un jeu (Admin)
+ *     description: Crée un nouveau jeu. Réservé aux administrateurs.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name, slug]
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 example: Chess
+ *               slug:
+ *                 type: string
+ *                 description: Identifiant unique en kebab-case
+ *                 example: chess
+ *               description:
+ *                 type: string
+ *                 example: Le jeu d'échecs classique.
+ *               coverImage:
+ *                 type: string
+ *                 format: uri
+ *                 example: https://example.com/chess.png
+ *     responses:
+ *       201:
+ *         description: Jeu créé
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 game:
+ *                   $ref: '#/components/schemas/Game'
+ *       400:
+ *         description: Validation échouée
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationError'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ */
 gamesRouter.post('/', isAuthenticated, isAdmin, gamesController.createGame);
+
+/**
+ * @openapi
+ * /games/{slug}:
+ *   get:
+ *     tags:
+ *       - Games
+ *     summary: Détails d'un jeu
+ *     parameters:
+ *       - in: path
+ *         name: slug
+ *         required: true
+ *         schema:
+ *           type: string
+ *           example: tic-tac-toe
+ *         description: Slug unique du jeu
+ *     responses:
+ *       200:
+ *         description: Détails du jeu
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 game:
+ *                   $ref: '#/components/schemas/Game'
+ *       404:
+ *         description: Jeu introuvable
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 gamesRouter.get('/:slug', gamesController.getGameBySlug);
+
+/**
+ * @openapi
+ * /games/{slug}:
+ *   patch:
+ *     tags:
+ *       - Games
+ *     summary: Modifier un jeu (Admin)
+ *     description: Met à jour les informations d'un jeu. Réservé aux administrateurs.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: slug
+ *         required: true
+ *         schema:
+ *           type: string
+ *           example: tic-tac-toe
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             minProperties: 1
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 example: Morpion
+ *               description:
+ *                 type: string
+ *                 example: Nouvelle description.
+ *               coverImage:
+ *                 type: string
+ *                 format: uri
+ *     responses:
+ *       200:
+ *         description: Jeu mis à jour
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 game:
+ *                   $ref: '#/components/schemas/Game'
+ *       400:
+ *         description: Validation échouée
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationError'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         description: Jeu introuvable
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 gamesRouter.patch('/:slug', isAuthenticated, isAdmin, gamesController.updateGame);
+
+/**
+ * @openapi
+ * /games/{slug}:
+ *   delete:
+ *     tags:
+ *       - Games
+ *     summary: Supprimer un jeu (Admin)
+ *     description: Supprime définitivement un jeu. Réservé aux administrateurs.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: slug
+ *         required: true
+ *         schema:
+ *           type: string
+ *           example: tic-tac-toe
+ *     responses:
+ *       204:
+ *         description: Jeu supprimé (aucun corps)
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         description: Jeu introuvable
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 gamesRouter.delete('/:slug', isAuthenticated, isAdmin, gamesController.deleteGame);
+
+/**
+ * @openapi
+ * /games/{slug}/leaderboard:
+ *   get:
+ *     tags:
+ *       - Games
+ *     summary: Classement d'un jeu
+ *     description: Retourne les meilleurs scores pour ce jeu, triés par valeur décroissante.
+ *     parameters:
+ *       - in: path
+ *         name: slug
+ *         required: true
+ *         schema:
+ *           type: string
+ *           example: tic-tac-toe
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 10
+ *         description: Nombre d'entrées à retourner
+ *     responses:
+ *       200:
+ *         description: Classement du jeu
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 leaderboard:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/LeaderboardEntry'
+ *       404:
+ *         description: Jeu introuvable
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 gamesRouter.get('/:slug/leaderboard', gamesController.getLeaderboard);
 
+/**
+ * @openapi
+ * /games/{slug}/scores:
+ *   post:
+ *     tags:
+ *       - Scores
+ *     summary: Soumettre un score
+ *     description: |
+ *       Soumet manuellement un score pour un jeu donné.
+ *
+ *       > **Note :** En pratique, les scores de match sont soumis **automatiquement**
+ *       > par le serveur via Socket.io à la fin de chaque partie. Cet endpoint est
+ *       > disponible pour des soumissions manuelles éventuelles.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: slug
+ *         required: true
+ *         schema:
+ *           type: string
+ *           example: tic-tac-toe
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [value]
+ *             properties:
+ *               value:
+ *                 type: integer
+ *                 minimum: 0
+ *                 example: 1
+ *     responses:
+ *       201:
+ *         description: Score enregistré
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 score:
+ *                   $ref: '#/components/schemas/Score'
+ *       400:
+ *         description: Validation échouée
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationError'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       404:
+ *         description: Jeu introuvable
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 gamesRouter.use('/:slug/scores', (req, res, next) => {
     req.params.gameSlug = req.params.slug;
     next();

--- a/src/modules/matches/matches.routes.ts
+++ b/src/modules/matches/matches.routes.ts
@@ -4,7 +4,164 @@ import { isAuthenticated } from '../../middlewares/auth.middleware';
 
 export const matchesRouter = Router();
 
+/**
+ * @openapi
+ * /matches:
+ *   post:
+ *     tags:
+ *       - Matches
+ *     summary: Créer un match
+ *     description: |
+ *       Crée un nouveau match en attente d'un second joueur.
+ *       Le créateur est automatiquement inscrit comme premier joueur.
+ *       Le match passe en statut `WAITING` jusqu'à ce qu'un second joueur le rejoigne.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [gameId]
+ *             properties:
+ *               gameId:
+ *                 type: string
+ *                 format: uuid
+ *                 description: Identifiant du jeu
+ *                 example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+ *     responses:
+ *       201:
+ *         description: Match créé (statut WAITING)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 match:
+ *                   $ref: '#/components/schemas/Match'
+ *       400:
+ *         description: Validation échouée ou jeu introuvable
+ *         content:
+ *           application/json:
+ *             schema:
+ *               oneOf:
+ *                 - $ref: '#/components/schemas/ValidationError'
+ *                 - $ref: '#/components/schemas/Error'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ */
 matchesRouter.post('/', isAuthenticated, matchesController.createMatch);
+
+/**
+ * @openapi
+ * /matches:
+ *   get:
+ *     tags:
+ *       - Matches
+ *     summary: Matches actifs
+ *     description: |
+ *       Liste tous les matches en cours (statut `WAITING` ou `ONGOING`),
+ *       triés par date de création décroissante.
+ *     responses:
+ *       200:
+ *         description: Liste des matches actifs
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 matches:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Match'
+ */
 matchesRouter.get('/', matchesController.getActiveMatches);
+
+/**
+ * @openapi
+ * /matches/{id}:
+ *   get:
+ *     tags:
+ *       - Matches
+ *     summary: Détails d'un match
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: Identifiant du match
+ *     responses:
+ *       200:
+ *         description: Détails du match
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 match:
+ *                   $ref: '#/components/schemas/Match'
+ *       404:
+ *         description: Match introuvable
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 matchesRouter.get('/:id', matchesController.getMatchById);
+
+/**
+ * @openapi
+ * /matches/{id}/join:
+ *   post:
+ *     tags:
+ *       - Matches
+ *     summary: Rejoindre un match
+ *     description: |
+ *       Inscrit l'utilisateur connecté à un match en attente (`WAITING`).
+ *
+ *       Dès que **2 joueurs** sont inscrits, le match passe automatiquement
+ *       en statut `ONGOING` et le GameState est initialisé en mémoire.
+ *       Les deux joueurs doivent ensuite se connecter via **Socket.io** pour jouer.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Match rejoint (peut être WAITING ou ONGOING)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 match:
+ *                   $ref: '#/components/schemas/Match'
+ *       400:
+ *         description: Impossible de rejoindre le match
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *             examples:
+ *               nonRejoignable:
+ *                 value: { message: "Cette partie ne peut plus être rejointe" }
+ *               dejaInscrit:
+ *                 value: { message: "Vous êtes déjà inscrit à cette partie" }
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       404:
+ *         description: Match introuvable
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 matchesRouter.post('/:id/join', isAuthenticated, matchesController.joinMatch);

--- a/src/modules/users/users.routes.ts
+++ b/src/modules/users/users.routes.ts
@@ -5,7 +5,156 @@ import { isAuthenticated } from '../../middlewares/auth.middleware';
 
 export const usersRouter = Router();
 
+/**
+ * @openapi
+ * /users/me:
+ *   get:
+ *     tags:
+ *       - Users
+ *     summary: Profil de l'utilisateur connecté
+ *     description: Retourne le profil complet depuis la base de données.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Profil de l'utilisateur
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 user:
+ *                   $ref: '#/components/schemas/User'
+ *       401:
+ *         description: Token absent ou invalide
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 usersRouter.get('/me', isAuthenticated, usersController.getMe);
+
+/**
+ * @openapi
+ * /users/me:
+ *   patch:
+ *     tags:
+ *       - Users
+ *     summary: Mettre à jour son profil
+ *     description: |
+ *       Modifie le profil de l'utilisateur connecté.
+ *       Au moins un des champs (`username` ou `email`) doit être renseigné.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             minProperties: 1
+ *             properties:
+ *               username:
+ *                 type: string
+ *                 minLength: 3
+ *                 maxLength: 20
+ *                 pattern: '^[a-zA-Z0-9_]+$'
+ *                 example: new_username
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 example: newemail@example.com
+ *     responses:
+ *       200:
+ *         description: Profil mis à jour
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 user:
+ *                   $ref: '#/components/schemas/User'
+ *       400:
+ *         description: Validation échouée ou email/username déjà utilisé
+ *         content:
+ *           application/json:
+ *             schema:
+ *               oneOf:
+ *                 - $ref: '#/components/schemas/ValidationError'
+ *                 - $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: Token absent ou invalide
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 usersRouter.patch('/me', isAuthenticated, usersController.updateMe);
+
+/**
+ * @openapi
+ * /users/me:
+ *   delete:
+ *     tags:
+ *       - Users
+ *     summary: Supprimer son compte
+ *     description: Supprime définitivement le compte de l'utilisateur connecté.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       204:
+ *         description: Compte supprimé avec succès (aucun corps)
+ *       401:
+ *         description: Token absent ou invalide
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 usersRouter.delete('/me', isAuthenticated, usersController.deleteMe);
+
+/**
+ * @openapi
+ * /users/me/scores:
+ *   get:
+ *     tags:
+ *       - Users
+ *     summary: Scores de l'utilisateur connecté
+ *     description: |
+ *       Retourne tous les scores de l'utilisateur connecté, triés par date décroissante.
+ *       Peut être filtré par jeu via le paramètre `gameSlug`.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: gameSlug
+ *         schema:
+ *           type: string
+ *           example: tic-tac-toe
+ *         description: Filtre les scores par jeu (slug)
+ *     responses:
+ *       200:
+ *         description: Liste des scores
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 scores:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/UserScore'
+ *       401:
+ *         description: Token absent ou invalide
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: Jeu introuvable (si gameSlug fourni et inconnu)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 usersRouter.get('/me/scores', isAuthenticated, scoresController.getUserScores);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -8,12 +8,101 @@ import * as adminService from '../modules/admin/admin.service';
 
 export const router = Router();
 
+/**
+ * @openapi
+ * components:
+ *   responses:
+ *     Unauthorized:
+ *       description: Token absent ou invalide
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Error'
+ *           example:
+ *             message: "Token manquant ou invalide"
+ *     Forbidden:
+ *       description: Droits insuffisants (rôle ADMIN requis)
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Error'
+ *           example:
+ *             message: "Accès refusé"
+ */
+
+/**
+ * @openapi
+ * /health:
+ *   get:
+ *     tags:
+ *       - Health
+ *     summary: Santé du serveur
+ *     description: Vérifie que le serveur est opérationnel.
+ *     responses:
+ *       200:
+ *         description: Serveur opérationnel
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: OK
+ *                 timestamp:
+ *                   type: string
+ *                   format: date-time
+ */
 router.get('/health', (req, res) => res.json({ status: 'OK', timestamp: new Date().toISOString() }));
+
 router.use('/auth', authRouter);
 router.use('/users', usersRouter);
 router.use('/games', gamesRouter);
 router.use('/matches', matchesRouter);
 router.use('/admin', adminRouter);
+
+/**
+ * @openapi
+ * /home-content:
+ *   get:
+ *     tags:
+ *       - Home
+ *     summary: Contenu de la page d'accueil
+ *     description: |
+ *       Retourne le contenu éditorial public de la page d'accueil,
+ *       trié par clé alphabétique.
+ *
+ *       **Clés disponibles :**
+ *       - `hero_cta` — Texte du bouton d'appel à l'action
+ *       - `hero_subtitle` — Sous-titre
+ *       - `hero_title` — Titre principal
+ *     responses:
+ *       200:
+ *         description: Contenu de la page d'accueil
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 content:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/HomeContent'
+ *             example:
+ *               content:
+ *                 - id: "uuid"
+ *                   key: "hero_cta"
+ *                   value: "Commencer à jouer"
+ *                   updatedAt: "2026-03-24T10:00:00.000Z"
+ *                 - id: "uuid"
+ *                   key: "hero_subtitle"
+ *                   value: "Affrontez vos amis en ligne sur nos jeux classiques."
+ *                   updatedAt: "2026-03-24T10:00:00.000Z"
+ *                 - id: "uuid"
+ *                   key: "hero_title"
+ *                   value: "Bienvenue sur GamePlatform"
+ *                   updatedAt: "2026-03-24T10:00:00.000Z"
+ */
 router.get('/home-content', async (req, res, next) => {
     try {
         const content = await adminService.getHomeContent();

--- a/wiki/api-reference.md
+++ b/wiki/api-reference.md
@@ -1,0 +1,1299 @@
+# API Reference — GamePlatform Backend
+
+Documentation destinée à l'équipe frontend (Next.js). Décrit l'ensemble des endpoints REST et des événements Socket.io disponibles.
+
+---
+
+## Sommaire
+
+1. [Informations générales](#1-informations-générales)
+2. [Authentification](#2-authentification)
+3. [Format des erreurs](#3-format-des-erreurs)
+4. [Modèles de données](#4-modèles-de-données)
+5. [Endpoints REST](#5-endpoints-rest)
+   - [Health](#51-health)
+   - [Auth](#52-auth)
+   - [Utilisateur connecté](#53-utilisateur-connecté)
+   - [Jeux](#54-jeux)
+   - [Scores](#55-scores)
+   - [Matches](#56-matches)
+   - [Contenu de la page d'accueil (public)](#57-contenu-de-la-page-daccueil-public)
+   - [Admin — Utilisateurs](#58-admin--utilisateurs)
+   - [Admin — Contenu de la page d'accueil](#59-admin--contenu-de-la-page-daccueil)
+6. [WebSocket (Socket.io)](#6-websocket-socketio)
+   - [Connexion](#61-connexion)
+   - [Événements émis par le client](#62-événements-émis-par-le-client)
+   - [Événements reçus par le client](#63-événements-reçus-par-le-client)
+   - [Cycle de vie d'un match](#64-cycle-de-vie-dun-match)
+   - [Format du GameState](#65-format-du-gamestate)
+   - [Logique Tic-Tac-Toe](#66-logique-tic-tac-toe)
+
+---
+
+## 1. Informations générales
+
+| Propriété | Valeur |
+|-----------|--------|
+| Base URL (développement) | `http://localhost:3000/api` |
+| Format des requêtes | `application/json` |
+| Format des réponses | `application/json` |
+| Authentification | JWT Bearer token |
+| WebSocket | `http://localhost:3000` (Socket.io v4) |
+
+Toutes les routes sont préfixées par `/api`. Exemple : `GET http://localhost:3000/api/health`.
+
+---
+
+## 2. Authentification
+
+Les routes protégées nécessitent un **Bearer token JWT** dans le header `Authorization` :
+
+```
+Authorization: Bearer <token>
+```
+
+Le token est obtenu lors du login (`POST /api/auth/login`) et est valable **7 jours**.
+
+### Niveaux d'accès
+
+| Niveau | Description |
+|--------|-------------|
+| Public | Aucun token requis |
+| `isAuthenticated` | Token JWT valide requis |
+| `isAdmin` | Token JWT avec `role: "ADMIN"` requis |
+
+### Payload JWT
+
+Le token contient les champs suivants (décodables côté client) :
+
+```json
+{
+  "sub": "uuid-utilisateur",
+  "role": "PLAYER",
+  "iat": 1234567890,
+  "exp": 1234567890
+}
+```
+
+---
+
+## 3. Format des erreurs
+
+Toutes les erreurs suivent un format unifié.
+
+### Erreur de validation (400)
+
+Déclenchée lorsque le body d'une requête ne passe pas la validation Zod.
+
+```json
+{
+  "message": "Erreur de validation",
+  "errors": [
+    {
+      "field": "email",
+      "message": "Adresse email invalide"
+    },
+    {
+      "field": "password",
+      "message": "Le mot de passe doit contenir au moins 8 caractères"
+    }
+  ]
+}
+```
+
+### Erreur métier (400 / 401 / 403 / 404 / 500)
+
+```json
+{
+  "message": "Description de l'erreur"
+}
+```
+
+### Codes HTTP utilisés
+
+| Code | Cas d'usage |
+|------|-------------|
+| `200` | Succès avec corps |
+| `201` | Ressource créée |
+| `204` | Succès sans corps (DELETE) |
+| `400` | Validation échouée ou règle métier violée |
+| `401` | Token absent ou invalide |
+| `403` | Token valide mais droits insuffisants |
+| `404` | Ressource introuvable |
+| `500` | Erreur interne serveur |
+
+---
+
+## 4. Modèles de données
+
+### User
+
+```ts
+{
+  id: string;          // UUID
+  email: string;
+  username: string;    // 3-20 caractères, alphanumérique + underscore
+  role: "PLAYER" | "ADMIN";
+  suspended: boolean;
+  createdAt: string;   // ISO 8601
+  updatedAt: string;   // ISO 8601
+}
+```
+
+> Le champ `passwordHash` n'est jamais renvoyé au client.
+
+### Game
+
+```ts
+{
+  id: string;           // UUID
+  name: string;
+  slug: string;         // ex: "tic-tac-toe"
+  description: string | null;
+  coverImage: string | null;
+  createdAt: string;    // ISO 8601
+}
+```
+
+### Match
+
+```ts
+{
+  id: string;           // UUID
+  status: "WAITING" | "ONGOING" | "FINISHED";
+  createdAt: string;    // ISO 8601
+  endedAt: string | null;
+  gameId: string;
+  game: {
+    id: string;
+    name: string;
+    slug: string;
+  };
+  players: MatchPlayer[];
+}
+```
+
+### MatchPlayer
+
+```ts
+{
+  matchId: string;
+  userId: string;
+  role: "PLAYER" | "SPECTATOR";
+  score: number | null;
+  user: {
+    id: string;
+    username: string;
+  };
+}
+```
+
+### Score
+
+```ts
+{
+  id: string;           // UUID
+  value: number;        // entier positif
+  createdAt: string;    // ISO 8601
+  user?: {              // présent dans le leaderboard
+    id: string;
+    username: string;
+  };
+  game?: {              // présent dans les scores de l'utilisateur
+    id: string;
+    name: string;
+    slug: string;
+  };
+}
+```
+
+### HomeContent
+
+```ts
+{
+  id: string;
+  key: string;          // ex: "hero_title"
+  value: string;
+  updatedAt: string;    // ISO 8601
+}
+```
+
+Clés disponibles après le seed :
+
+| Clé | Valeur par défaut |
+|-----|-------------------|
+| `hero_title` | `"Bienvenue sur GamePlatform"` |
+| `hero_subtitle` | `"Affrontez vos amis en ligne sur nos jeux classiques."` |
+| `hero_cta` | `"Commencer à jouer"` |
+
+---
+
+## 5. Endpoints REST
+
+### 5.1 Health
+
+#### `GET /api/health`
+
+Vérifie que le serveur est opérationnel.
+
+**Accès :** Public
+
+**Réponse `200` :**
+```json
+{
+  "status": "OK",
+  "timestamp": "2026-03-24T10:00:00.000Z"
+}
+```
+
+---
+
+### 5.2 Auth
+
+#### `POST /api/auth/register`
+
+Crée un nouveau compte utilisateur.
+
+**Accès :** Public
+
+**Body :**
+```json
+{
+  "email": "user@example.com",
+  "username": "my_username",
+  "password": "monMotDePasse123"
+}
+```
+
+| Champ | Contraintes |
+|-------|-------------|
+| `email` | Email valide |
+| `username` | 3–20 caractères, `[a-zA-Z0-9_]` uniquement |
+| `password` | Minimum 8 caractères |
+
+**Réponse `201` :**
+```json
+{
+  "user": {
+    "id": "uuid",
+    "email": "user@example.com",
+    "username": "my_username",
+    "role": "PLAYER",
+    "createdAt": "2026-03-24T10:00:00.000Z"
+  }
+}
+```
+
+**Erreurs possibles :**
+- `400` — Email déjà utilisé : `"Cette adresse email est déjà utilisée"`
+- `400` — Username déjà pris : `"Ce nom d'utilisateur est déjà pris"`
+- `400` — Validation échouée
+
+---
+
+#### `POST /api/auth/login`
+
+Authentifie un utilisateur et retourne un token JWT.
+
+**Accès :** Public
+
+**Body :**
+```json
+{
+  "email": "user@example.com",
+  "password": "monMotDePasse123"
+}
+```
+
+**Réponse `200` :**
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "user": {
+    "id": "uuid",
+    "email": "user@example.com",
+    "username": "my_username",
+    "role": "PLAYER",
+    "createdAt": "2026-03-24T10:00:00.000Z"
+  }
+}
+```
+
+**Erreurs possibles :**
+- `400` — Identifiants invalides : `"Identifiants invalides"`
+- `400` — Compte suspendu : `"Ce compte est suspendu"`
+
+> Le token doit être stocké côté client (localStorage ou cookie httpOnly) et envoyé dans le header `Authorization: Bearer <token>` pour toutes les requêtes protégées.
+
+---
+
+#### `GET /api/auth/me`
+
+Retourne les informations de l'utilisateur à partir de son token JWT.
+
+**Accès :** `isAuthenticated`
+
+**Réponse `200` :**
+```json
+{
+  "user": {
+    "id": "uuid",
+    "email": "user@example.com",
+    "username": "my_username",
+    "role": "PLAYER"
+  }
+}
+```
+
+> Retourne les données du payload JWT, pas une requête BDD. Préférer `GET /api/users/me` pour les données fraîches.
+
+---
+
+### 5.3 Utilisateur connecté
+
+#### `GET /api/users/me`
+
+Retourne le profil complet de l'utilisateur connecté depuis la base de données.
+
+**Accès :** `isAuthenticated`
+
+**Réponse `200` :**
+```json
+{
+  "user": {
+    "id": "uuid",
+    "email": "user@example.com",
+    "username": "my_username",
+    "role": "PLAYER",
+    "suspended": false,
+    "createdAt": "2026-03-24T10:00:00.000Z",
+    "updatedAt": "2026-03-24T10:00:00.000Z"
+  }
+}
+```
+
+---
+
+#### `PATCH /api/users/me`
+
+Met à jour le profil de l'utilisateur connecté.
+
+**Accès :** `isAuthenticated`
+
+**Body :** (au moins un champ requis)
+```json
+{
+  "username": "new_username",
+  "email": "newemail@example.com"
+}
+```
+
+| Champ | Contraintes |
+|-------|-------------|
+| `username` | Optionnel, 3–20 caractères, `[a-zA-Z0-9_]` |
+| `email` | Optionnel, email valide |
+
+**Réponse `200` :**
+```json
+{
+  "user": {
+    "id": "uuid",
+    "email": "newemail@example.com",
+    "username": "new_username",
+    "role": "PLAYER",
+    "suspended": false,
+    "createdAt": "2026-03-24T10:00:00.000Z",
+    "updatedAt": "2026-03-24T10:05:00.000Z"
+  }
+}
+```
+
+**Erreurs possibles :**
+- `400` — Aucun champ fourni
+- `400` — Email ou username déjà utilisé
+
+---
+
+#### `DELETE /api/users/me`
+
+Supprime définitivement le compte de l'utilisateur connecté.
+
+**Accès :** `isAuthenticated`
+
+**Réponse `204` :** (aucun corps)
+
+---
+
+#### `GET /api/users/me/scores`
+
+Retourne les scores de l'utilisateur connecté. Filtrable par jeu.
+
+**Accès :** `isAuthenticated`
+
+**Query params :**
+| Paramètre | Type | Description |
+|-----------|------|-------------|
+| `gameSlug` | `string` (optionnel) | Filtre par jeu (ex: `tic-tac-toe`) |
+
+**Exemple :** `GET /api/users/me/scores?gameSlug=tic-tac-toe`
+
+**Réponse `200` :**
+```json
+{
+  "scores": [
+    {
+      "id": "uuid",
+      "value": 1,
+      "createdAt": "2026-03-24T10:00:00.000Z",
+      "game": {
+        "id": "uuid",
+        "name": "Tic-Tac-Toe",
+        "slug": "tic-tac-toe"
+      }
+    }
+  ]
+}
+```
+
+---
+
+### 5.4 Jeux
+
+#### `GET /api/games`
+
+Liste tous les jeux disponibles.
+
+**Accès :** Public
+
+**Réponse `200` :**
+```json
+{
+  "games": [
+    {
+      "id": "uuid",
+      "name": "Tic-Tac-Toe",
+      "slug": "tic-tac-toe",
+      "description": "Le classique jeu de morpion à deux joueurs.",
+      "coverImage": null,
+      "createdAt": "2026-03-24T10:00:00.000Z"
+    }
+  ]
+}
+```
+
+---
+
+#### `GET /api/games/:slug`
+
+Retourne les détails d'un jeu par son slug.
+
+**Accès :** Public
+
+**Exemple :** `GET /api/games/tic-tac-toe`
+
+**Réponse `200` :**
+```json
+{
+  "game": {
+    "id": "uuid",
+    "name": "Tic-Tac-Toe",
+    "slug": "tic-tac-toe",
+    "description": "Le classique jeu de morpion à deux joueurs.",
+    "coverImage": null,
+    "createdAt": "2026-03-24T10:00:00.000Z"
+  }
+}
+```
+
+**Erreurs possibles :**
+- `404` — `"Jeu introuvable"`
+
+---
+
+#### `GET /api/games/:slug/leaderboard`
+
+Retourne le classement du jeu.
+
+**Accès :** Public
+
+**Query params :**
+| Paramètre | Type | Défaut | Maximum |
+|-----------|------|--------|---------|
+| `limit` | `number` | `10` | `100` |
+
+**Exemple :** `GET /api/games/tic-tac-toe/leaderboard?limit=5`
+
+**Réponse `200` :**
+```json
+{
+  "leaderboard": [
+    {
+      "id": "uuid",
+      "value": 1,
+      "createdAt": "2026-03-24T10:00:00.000Z",
+      "user": {
+        "id": "uuid",
+        "username": "champion"
+      }
+    }
+  ]
+}
+```
+
+> Les scores sont triés par valeur décroissante.
+
+---
+
+#### `POST /api/games` — Admin
+
+Crée un nouveau jeu.
+
+**Accès :** `isAdmin`
+
+**Body :**
+```json
+{
+  "name": "Chess",
+  "slug": "chess",
+  "description": "Le jeu d'échecs classique.",
+  "coverImage": "https://example.com/chess.png"
+}
+```
+
+| Champ | Contraintes |
+|-------|-------------|
+| `name` | Requis, string non vide |
+| `slug` | Requis, format kebab-case unique |
+| `description` | Optionnel |
+| `coverImage` | Optionnel, URL |
+
+**Réponse `201` :**
+```json
+{
+  "game": { ... }
+}
+```
+
+---
+
+#### `PATCH /api/games/:slug` — Admin
+
+Met à jour un jeu existant.
+
+**Accès :** `isAdmin`
+
+**Body :** (tous les champs optionnels)
+```json
+{
+  "name": "Nouveau nom",
+  "description": "Nouvelle description"
+}
+```
+
+**Réponse `200` :**
+```json
+{
+  "game": { ... }
+}
+```
+
+---
+
+#### `DELETE /api/games/:slug` — Admin
+
+Supprime un jeu.
+
+**Accès :** `isAdmin`
+
+**Réponse `204` :** (aucun corps)
+
+---
+
+### 5.5 Scores
+
+#### `POST /api/games/:gameSlug/scores`
+
+Soumet un score pour un jeu.
+
+**Accès :** `isAuthenticated`
+
+**Exemple :** `POST /api/games/tic-tac-toe/scores`
+
+**Body :**
+```json
+{
+  "value": 1
+}
+```
+
+| Champ | Contraintes |
+|-------|-------------|
+| `value` | Entier positif ou nul |
+
+**Réponse `201` :**
+```json
+{
+  "score": {
+    "id": "uuid",
+    "value": 1,
+    "createdAt": "2026-03-24T10:00:00.000Z",
+    "userId": "uuid",
+    "gameId": "uuid"
+  }
+}
+```
+
+> En pratique, les scores de match sont soumis **automatiquement** par le serveur à la fin d'un match via Socket.io. Cet endpoint est disponible pour des soumissions manuelles éventuelles.
+
+---
+
+### 5.6 Matches
+
+#### `GET /api/matches`
+
+Liste les matches actifs (statut `WAITING` ou `ONGOING`).
+
+**Accès :** Public
+
+**Réponse `200` :**
+```json
+{
+  "matches": [
+    {
+      "id": "uuid",
+      "status": "WAITING",
+      "createdAt": "2026-03-24T10:00:00.000Z",
+      "endedAt": null,
+      "gameId": "uuid",
+      "game": {
+        "id": "uuid",
+        "name": "Tic-Tac-Toe",
+        "slug": "tic-tac-toe"
+      },
+      "players": [
+        {
+          "matchId": "uuid",
+          "userId": "uuid",
+          "role": "PLAYER",
+          "score": null,
+          "user": {
+            "id": "uuid",
+            "username": "player1"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+#### `GET /api/matches/:id`
+
+Retourne les détails d'un match spécifique.
+
+**Accès :** Public
+
+**Réponse `200` :**
+```json
+{
+  "match": {
+    "id": "uuid",
+    "status": "ONGOING",
+    "createdAt": "2026-03-24T10:00:00.000Z",
+    "endedAt": null,
+    "game": { ... },
+    "players": [ ... ]
+  }
+}
+```
+
+**Erreurs possibles :**
+- `404` — `"Match introuvable"`
+
+---
+
+#### `POST /api/matches`
+
+Crée un nouveau match.
+
+**Accès :** `isAuthenticated`
+
+**Body :**
+```json
+{
+  "gameId": "uuid-du-jeu"
+}
+```
+
+**Réponse `201` :**
+```json
+{
+  "match": {
+    "id": "uuid",
+    "status": "WAITING",
+    "game": { ... },
+    "players": [
+      {
+        "userId": "uuid-du-créateur",
+        "role": "PLAYER",
+        "score": null,
+        "user": { "id": "uuid", "username": "player1" }
+      }
+    ]
+  }
+}
+```
+
+> Le créateur est automatiquement inscrit comme premier joueur. Le match passe en `WAITING` jusqu'à ce qu'un second joueur rejoigne.
+
+---
+
+#### `POST /api/matches/:id/join`
+
+Rejoint un match en attente.
+
+**Accès :** `isAuthenticated`
+
+**Réponse `200` :**
+```json
+{
+  "match": {
+    "id": "uuid",
+    "status": "ONGOING",
+    "game": { ... },
+    "players": [
+      { "userId": "uuid-player1", "role": "PLAYER", "score": null, "user": { ... } },
+      { "userId": "uuid-player2", "role": "PLAYER", "score": null, "user": { ... } }
+    ]
+  }
+}
+```
+
+> Quand 2 joueurs sont inscrits, le statut passe automatiquement à `ONGOING` et le `GameState` est initialisé en mémoire. Les deux joueurs doivent ensuite se connecter via Socket.io pour jouer.
+
+**Erreurs possibles :**
+- `400` — `"Cette partie ne peut plus être rejointe"` (statut != WAITING)
+- `400` — `"Vous êtes déjà inscrit à cette partie"`
+- `404` — `"Match introuvable"`
+
+---
+
+### 5.7 Contenu de la page d'accueil (public)
+
+#### `GET /api/home-content`
+
+Retourne le contenu éditorial de la page d'accueil.
+
+**Accès :** Public
+
+**Réponse `200` :**
+```json
+{
+  "content": [
+    { "id": "uuid", "key": "hero_cta", "value": "Commencer à jouer", "updatedAt": "..." },
+    { "id": "uuid", "key": "hero_subtitle", "value": "Affrontez vos amis en ligne sur nos jeux classiques.", "updatedAt": "..." },
+    { "id": "uuid", "key": "hero_title", "value": "Bienvenue sur GamePlatform", "updatedAt": "..." }
+  ]
+}
+```
+
+> Le tableau est trié par clé alphabétique.
+
+---
+
+### 5.8 Admin — Utilisateurs
+
+Tous les endpoints ci-dessous nécessitent un token avec `role: "ADMIN"`.
+
+#### `GET /api/admin/users`
+
+Liste paginée des utilisateurs avec filtre de recherche optionnel.
+
+**Accès :** `isAdmin`
+
+**Query params :**
+| Paramètre | Type | Défaut | Maximum |
+|-----------|------|--------|---------|
+| `page` | `number` | `1` | — |
+| `limit` | `number` | `20` | `100` |
+| `search` | `string` | — | — |
+
+**Exemple :** `GET /api/admin/users?page=1&limit=20&search=alice`
+
+La recherche porte sur `username` et `email` (insensible à la casse).
+
+**Réponse `200` :**
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "email": "alice@example.com",
+      "username": "alice",
+      "role": "PLAYER",
+      "suspended": false,
+      "createdAt": "2026-03-24T10:00:00.000Z",
+      "updatedAt": "2026-03-24T10:00:00.000Z"
+    }
+  ],
+  "total": 42,
+  "page": 1,
+  "limit": 20
+}
+```
+
+---
+
+#### `PATCH /api/admin/users/:id/suspend`
+
+Suspend ou réactive un compte utilisateur.
+
+**Accès :** `isAdmin`
+
+**Body :**
+```json
+{
+  "suspended": true
+}
+```
+
+| Champ | Contraintes |
+|-------|-------------|
+| `suspended` | Booléen requis |
+
+**Réponse `200` :**
+```json
+{
+  "user": {
+    "id": "uuid",
+    "email": "alice@example.com",
+    "username": "alice",
+    "role": "PLAYER",
+    "suspended": true,
+    "createdAt": "...",
+    "updatedAt": "..."
+  }
+}
+```
+
+**Erreurs possibles :**
+- `400` — `"Le champ suspended doit être un booléen"`
+- `404` — `"Utilisateur introuvable"`
+
+---
+
+#### `DELETE /api/admin/users/:id`
+
+Supprime définitivement un compte utilisateur.
+
+**Accès :** `isAdmin`
+
+**Réponse `204` :** (aucun corps)
+
+**Erreurs possibles :**
+- `404` — `"Utilisateur introuvable"`
+
+---
+
+### 5.9 Admin — Contenu de la page d'accueil
+
+#### `GET /api/admin/home-content`
+
+Retourne tout le contenu éditorial (identique au endpoint public).
+
+**Accès :** `isAdmin`
+
+**Réponse `200` :**
+```json
+{
+  "content": [
+    { "id": "uuid", "key": "hero_title", "value": "Bienvenue sur GamePlatform", "updatedAt": "..." }
+  ]
+}
+```
+
+---
+
+#### `PATCH /api/admin/home-content/:key`
+
+Crée ou met à jour une entrée de contenu par sa clé.
+
+**Accès :** `isAdmin`
+
+**Exemple :** `PATCH /api/admin/home-content/hero_title`
+
+**Body :**
+```json
+{
+  "value": "Bienvenue sur la plateforme de jeux !"
+}
+```
+
+| Champ | Contraintes |
+|-------|-------------|
+| `value` | String non vide, requis |
+
+**Réponse `200` :**
+```json
+{
+  "item": {
+    "id": "uuid",
+    "key": "hero_title",
+    "value": "Bienvenue sur la plateforme de jeux !",
+    "updatedAt": "2026-03-24T10:05:00.000Z"
+  }
+}
+```
+
+---
+
+## 6. WebSocket (Socket.io)
+
+Le serveur expose un serveur Socket.io sur le même port que l'API REST.
+
+### 6.1 Connexion
+
+La connexion **requiert un token JWT** passé dans les options d'authentification du handshake.
+
+```ts
+import { io } from 'socket.io-client';
+
+const socket = io('http://localhost:3000', {
+  auth: {
+    token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  },
+});
+
+socket.on('connect', () => {
+  console.log('Connecté :', socket.id);
+});
+
+socket.on('connect_error', (err) => {
+  // err.message === 'Unauthorized' si le token est absent ou invalide
+  console.error('Erreur de connexion :', err.message);
+});
+```
+
+> Sans token valide, la connexion est rejetée avec `connect_error`.
+
+---
+
+### 6.2 Événements émis par le client
+
+#### `join-match`
+
+Rejoint la room Socket.io d'un match en tant que **joueur**.
+
+> Prérequis : l'utilisateur doit d'abord avoir rejoint le match via `POST /api/matches/:id/join` (REST).
+
+```ts
+socket.emit('join-match', { matchId: 'uuid-du-match' });
+```
+
+**Payload :**
+```ts
+{ matchId: string }
+```
+
+**Effets :**
+- Le client intègre la room `match:<matchId>`
+- Le serveur envoie immédiatement un événement `state-update` avec l'état courant du match
+
+**Erreurs possibles (via événement `error`) :**
+- `"Match introuvable"`
+- `"Vous ne faites pas partie de cette partie"`
+- `"Erreur lors de la connexion à la partie"`
+
+---
+
+#### `join-as-spectator`
+
+Rejoint la room d'un match en tant que **spectateur**.
+
+```ts
+socket.emit('join-as-spectator', { matchId: 'uuid-du-match' });
+```
+
+**Payload :**
+```ts
+{ matchId: string }
+```
+
+**Conditions :**
+- Le match doit être en statut `ONGOING`
+- Le spectateur reçoit `state-update` mais ne peut pas émettre `game-action`
+
+**Erreurs possibles (via événement `error`) :**
+- `"Cette partie ne peut pas être observée"` (match non ONGOING ou introuvable)
+
+---
+
+#### `game-action`
+
+Joue un coup dans le match.
+
+```ts
+socket.emit('game-action', {
+  matchId: 'uuid-du-match',
+  action: { index: 4 }, // case du plateau (0-8)
+});
+```
+
+**Payload :**
+```ts
+{
+  matchId: string;
+  action: { index: number }; // 0 à 8 pour Tic-Tac-Toe
+}
+```
+
+**Conditions :**
+- L'émetteur doit être un joueur (pas un spectateur)
+- C'est le tour de l'émetteur (`state.currentTurn === userId`)
+- La case doit être libre
+
+**Effets en cas de succès :**
+- L'état du plateau est mis à jour
+- Tous les membres de la room reçoivent `state-update`
+- Si la partie est terminée, tous reçoivent `match-end`
+
+**Erreurs possibles (via événement `error`) :**
+- `"Partie introuvable en mémoire"`
+- `"Ce n'est pas votre tour"`
+- `"Cette case est déjà occupée"` (ou toute erreur de logique Tic-Tac-Toe)
+
+---
+
+#### `leave-match`
+
+Quitte la room d'un match proprement (sans forfait).
+
+```ts
+socket.emit('leave-match', { matchId: 'uuid-du-match' });
+```
+
+**Payload :**
+```ts
+{ matchId: string }
+```
+
+> Un spectateur qui quitte ne déclenche aucune fin de match.
+
+---
+
+### 6.3 Événements reçus par le client
+
+#### `state-update`
+
+Reçu après `join-match`, `join-as-spectator` ou après chaque `game-action`.
+
+```ts
+socket.on('state-update', (state: GameState) => {
+  // Mettre à jour l'affichage du plateau
+});
+```
+
+**Voir [section 6.5](#65-format-du-gamestate) pour le format complet.**
+
+---
+
+#### `match-end`
+
+Reçu par tous les membres de la room quand le match se termine (victoire, nul ou forfait).
+
+```ts
+socket.on('match-end', (data) => {
+  console.log('Fin du match :', data);
+});
+```
+
+**Payload :**
+```ts
+{
+  scores: Array<{
+    userId: string;
+    score: number;  // 1 = victoire, 0 = défaite/nul
+  }>;
+  winnerId: string | null;  // null en cas de match nul
+  isDraw: boolean;
+  reason?: 'forfeit';       // présent uniquement en cas de déconnexion
+}
+```
+
+**Exemples :**
+
+Victoire normale :
+```json
+{
+  "scores": [
+    { "userId": "player1-id", "score": 1 },
+    { "userId": "player2-id", "score": 0 }
+  ],
+  "winnerId": "player1-id",
+  "isDraw": false
+}
+```
+
+Match nul :
+```json
+{
+  "scores": [
+    { "userId": "player1-id", "score": 0 },
+    { "userId": "player2-id", "score": 0 }
+  ],
+  "winnerId": null,
+  "isDraw": true
+}
+```
+
+Forfait (déconnexion) :
+```json
+{
+  "scores": [
+    { "userId": "player1-id", "score": 1 },
+    { "userId": "player2-id", "score": 0 }
+  ],
+  "winnerId": "player1-id",
+  "isDraw": false,
+  "reason": "forfeit"
+}
+```
+
+---
+
+#### `error`
+
+Reçu en cas d'erreur côté serveur lors du traitement d'un événement.
+
+```ts
+socket.on('error', (data: { message: string }) => {
+  console.error('Erreur serveur :', data.message);
+});
+```
+
+---
+
+### 6.4 Cycle de vie d'un match
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    FLUX COMPLET                          │
+└─────────────────────────────────────────────────────────┘
+
+1. Player 1  →  POST /api/matches          (crée, status: WAITING)
+2. Player 2  →  POST /api/matches/:id/join (status: ONGOING, GameState init)
+
+3. Player 1  →  socket.emit('join-match', { matchId })
+                ← state-update (plateau vide, tour de Player 1)
+
+4. Player 2  →  socket.emit('join-match', { matchId })
+                ← state-update (plateau vide, tour de Player 1)
+
+5. Player 1  →  socket.emit('game-action', { matchId, action: { index: 4 } })
+                ← state-update (plateau mis à jour, tour de Player 2)
+
+6. Player 2  →  socket.emit('game-action', { matchId, action: { index: 0 } })
+                ← state-update
+
+   ... (alternance des tours) ...
+
+7. Fin de partie
+                ← match-end { scores, winnerId, isDraw }
+```
+
+> **Important :** Si un joueur se déconnecte pendant un match `ONGOING`, l'adversaire gagne automatiquement par forfait et `match-end` est émis avec `reason: "forfeit"`.
+
+---
+
+### 6.5 Format du GameState
+
+L'état reçu via `state-update` :
+
+```ts
+interface GameState {
+  matchId: string;
+  gameSlug: string;        // ex: "tic-tac-toe"
+  board: (string | null)[] | null;  // null avant le premier coup
+  currentTurn: string;     // userId du joueur dont c'est le tour
+  players: string[];       // [userId1, userId2] — ordre fixe
+  spectators: string[];    // userIds des spectateurs connectés
+  startedAt: string;       // Date ISO
+}
+```
+
+> **Note :** Le champ `socketIds` (Map interne) n'est pas sérialisable en JSON et sera absent ou vide dans la réponse.
+
+---
+
+### 6.6 Logique Tic-Tac-Toe
+
+Le plateau est un tableau de 9 cases, indexées de 0 à 8 :
+
+```
+ 0 | 1 | 2
+-----------
+ 3 | 4 | 5
+-----------
+ 6 | 7 | 8
+```
+
+Chaque case contient :
+- `null` — case vide
+- `string` — `userId` du joueur qui a joué cette case
+
+**Combinaisons gagnantes :**
+```
+Lignes    : [0,1,2], [3,4,5], [6,7,8]
+Colonnes  : [0,3,6], [1,4,7], [2,5,8]
+Diagonales: [0,4,8], [2,4,6]
+```
+
+**La partie se termine quand :**
+- Un joueur aligne 3 cases → `isDraw: false`, `winnerId: userId`
+- Les 9 cases sont remplies sans vainqueur → `isDraw: true`, `winnerId: null`
+
+**Exemple de plateau après quelques coups :**
+```json
+{
+  "board": [
+    "player2-id", null,         "player1-id",
+    null,         "player1-id", null,
+    null,         null,         null
+  ],
+  "currentTurn": "player2-id"
+}
+```
+
+---
+
+## Récapitulatif des routes
+
+| Méthode | Endpoint | Accès | Description |
+|---------|----------|-------|-------------|
+| `GET` | `/api/health` | Public | Santé du serveur |
+| `POST` | `/api/auth/register` | Public | Inscription |
+| `POST` | `/api/auth/login` | Public | Connexion, retourne token |
+| `GET` | `/api/auth/me` | Auth | Profil depuis le token |
+| `GET` | `/api/users/me` | Auth | Profil depuis la BDD |
+| `PATCH` | `/api/users/me` | Auth | Modifier son profil |
+| `DELETE` | `/api/users/me` | Auth | Supprimer son compte |
+| `GET` | `/api/users/me/scores` | Auth | Ses propres scores |
+| `GET` | `/api/games` | Public | Liste des jeux |
+| `GET` | `/api/games/:slug` | Public | Détails d'un jeu |
+| `GET` | `/api/games/:slug/leaderboard` | Public | Classement d'un jeu |
+| `POST` | `/api/games` | Admin | Créer un jeu |
+| `PATCH` | `/api/games/:slug` | Admin | Modifier un jeu |
+| `DELETE` | `/api/games/:slug` | Admin | Supprimer un jeu |
+| `POST` | `/api/games/:gameSlug/scores` | Auth | Soumettre un score |
+| `GET` | `/api/matches` | Public | Matches actifs |
+| `GET` | `/api/matches/:id` | Public | Détails d'un match |
+| `POST` | `/api/matches` | Auth | Créer un match |
+| `POST` | `/api/matches/:id/join` | Auth | Rejoindre un match |
+| `GET` | `/api/home-content` | Public | Contenu page d'accueil |
+| `GET` | `/api/admin/users` | Admin | Liste paginée des users |
+| `PATCH` | `/api/admin/users/:id/suspend` | Admin | Suspendre/réactiver un user |
+| `DELETE` | `/api/admin/users/:id` | Admin | Supprimer un user |
+| `GET` | `/api/admin/home-content` | Admin | Contenu éditorial (admin) |
+| `PATCH` | `/api/admin/home-content/:key` | Admin | Modifier contenu éditorial |


### PR DESCRIPTION
Ajoute une documentation OpenAPI 3.0 auto-générée via swagger-jsdoc. Les annotations @openapi sont placées directement dans chaque fichier de routes (pattern similaire aux annotations Java).

- src/config/swagger.ts : config swagger-jsdoc + schemas réutilisables (User, Game, Match, Score, HomeContent, Error, ValidationError)
- src/app.ts : Swagger UI sur /api/docs, spec JSON sur /api/docs.json
- Annotations sur 19 endpoints (auth, users, games, scores, matches, admin)
- Réponses réutilisables $ref (Unauthorized, Forbidden)
- wiki/api-reference.md : documentation narrative complète pour le front